### PR TITLE
ociregistry/ociclient: verify content when read from server

### DIFF
--- a/ociregistry/ociclient/client.go
+++ b/ociregistry/ociclient/client.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash"
 	"io"
 	"log"
 	"net/http"
@@ -118,13 +119,63 @@ func descriptorFromResponse(resp *http.Response, knownDigest digest.Digest, requ
 	}, nil
 }
 
+func newBlobReader(r io.ReadCloser, desc ociregistry.Descriptor) *blobReader {
+	return &blobReader{
+		r:        r,
+		digester: desc.Digest.Algorithm().Hash(),
+		desc:     desc,
+		verify:   true,
+	}
+}
+
+func newBlobReaderUnverified(r io.ReadCloser, desc ociregistry.Descriptor) *blobReader {
+	br := newBlobReader(r, desc)
+	br.verify = false
+	return br
+}
+
 type blobReader struct {
-	io.ReadCloser
-	desc ociregistry.Descriptor
+	r        io.ReadCloser
+	n        int64
+	digester hash.Hash
+	desc     ociregistry.Descriptor
+	verify   bool
 }
 
 func (r *blobReader) Descriptor() ociregistry.Descriptor {
 	return r.desc
+}
+
+func (r *blobReader) Read(buf []byte) (int, error) {
+	n, err := r.r.Read(buf)
+	r.n += int64(n)
+	r.digester.Write(buf[:n])
+	if err == nil {
+		if r.n > r.desc.Size {
+			// Fail early when the blob is too big; we can do that even
+			// when we're not verifying for other use cases.
+			return n, fmt.Errorf("blob size exceeds content length %d: %w", r.desc.Size, ociregistry.ErrSizeInvalid)
+		}
+		return n, nil
+	}
+	if err != io.EOF {
+		return n, err
+	}
+	if !r.verify {
+		return n, io.EOF
+	}
+	if r.n != r.desc.Size {
+		return n, fmt.Errorf("blob size mismatch (%d/%d): %w", r.n, r.desc.Size, ociregistry.ErrSizeInvalid)
+	}
+	gotDigest := digest.NewDigest(r.desc.Digest.Algorithm(), r.digester)
+	if gotDigest != r.desc.Digest {
+		return n, fmt.Errorf("digest mismatch when reading blob")
+	}
+	return n, io.EOF
+}
+
+func (r *blobReader) Close() error {
+	return r.r.Close()
 }
 
 func isValidDigest(d string) bool {
@@ -152,7 +203,7 @@ func (c *client) doRequest(ctx context.Context, rreq *ocirequest.Request, okStat
 	if err != nil {
 		return nil, err
 	}
-	if rreq.Kind == ocirequest.ReqManifestGet {
+	if rreq.Kind == ocirequest.ReqManifestGet || rreq.Kind == ocirequest.ReqManifestHead {
 		// When getting manifests, some servers won't return
 		// the content unless there's an Accept header, so
 		// add all the manifest kinds that we know about.

--- a/ociregistry/ociclient/reader.go
+++ b/ociregistry/ociclient/reader.go
@@ -48,10 +48,7 @@ func (c *client) GetBlobRange(ctx context.Context, repo string, digest ociregist
 	if err != nil {
 		return nil, fmt.Errorf("invalid descriptor in response: %v", err)
 	}
-	return &blobReader{
-		ReadCloser: resp.Body,
-		desc:       desc,
-	}, nil
+	return newBlobReaderUnverified(resp.Body, desc), nil
 }
 
 func (c *client) ResolveBlob(ctx context.Context, repo string, digest ociregistry.Digest) (ociregistry.Descriptor, error) {
@@ -117,8 +114,5 @@ func (c *client) read(ctx context.Context, rreq *ocirequest.Request) (_ ociregis
 	if err != nil {
 		return nil, fmt.Errorf("invalid descriptor in response: %v", err)
 	}
-	return &blobReader{
-		ReadCloser: resp.Body,
-		desc:       desc,
-	}, nil
+	return newBlobReader(resp.Body, desc), nil
 }


### PR DESCRIPTION
This makes sure that we won't accidentally read dubious content that doesn't match the stated digest.