### PR TITLE
ociregistry/ociclient: use host not URL

### DIFF
--- a/cmd/ocisrv/main_test.go
+++ b/cmd/ocisrv/main_test.go
@@ -132,8 +132,7 @@ func connect(ts *testscript.TestScript) (ociregistry.Interface, error) {
 			return nil, fmt.Errorf("timed out waiting for server")
 		}
 	}
-	hostURL := "http://" + addr
-	resp, err := http.Get(hostURL + "/v2/")
+	resp, err := http.Get("http://" + addr + "/v2/")
 	if err != nil {
 		return nil, fmt.Errorf("cannot ping server: %v", err)
 	}
@@ -141,7 +140,9 @@ func connect(ts *testscript.TestScript) (ociregistry.Interface, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected ping status (%v)", resp.Status)
 	}
-	return ociclient.New(hostURL, nil), nil
+	return ociclient.New(addr, &ociclient.Options{
+		Insecure: true,
+	})
 }
 
 func writeNetAddrForTest(l net.Listener) {

--- a/cmd/ocisrv/registry.go
+++ b/cmd/ocisrv/registry.go
@@ -40,14 +40,16 @@ type registry interface {
 }
 
 type clientRegistry struct {
-	HostURL string `json:"hostURL"`
-	DebugID string `json:"debugID,omitempty"`
+	Host     string `json:"host"`
+	Insecure bool   `json:"insecure"`
+	DebugID  string `json:"debugID,omitempty"`
 }
 
 func (r clientRegistry) new() (ociregistry.Interface, error) {
-	return ociclient.New(r.HostURL, &ociclient.Options{
-		DebugID: r.DebugID,
-	}), nil
+	return ociclient.New(r.Host, &ociclient.Options{
+		DebugID:  r.DebugID,
+		Insecure: r.Insecure,
+	})
 }
 
 type selectRegistry struct {


### PR DESCRIPTION
We use only the host, which maps better to using the host part of an OCI reference, and means that we sidestep awkward questions about what to do when there's a path or query components to the URL.