### PR TITLE
doc: Don't vendor a copy of DCO, as it is under another license.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,48 +57,7 @@ of Origin.
 ### Asserting a Developer Certificate of Origin
 
 Contributions must be accompanied by a [Developer Certificate of
-Origin](https://developercertificate.org/), the text of which is reproduced here
-for convenience:
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
+Origin](https://developercertificate.org/), we are using version 1.1.
 
 All commit messages must contain the `Signed-off-by` line with an email address
 that matches the commit author. This line asserts the Developer Certificate of Origin.


### PR DESCRIPTION
Hi.  I'm packaging cue for Debian which are careful about licenses practices.  I noticed that CONTRIBUTING.md includes a vendored copy of a file that is not under your project license, and the license of this text doesn't even allow modifications so it cannot be included into Debian.  Would you consider dropping the copy of the DCO and merely reference it?  

Thanks,
Simon