### PR TITLE
ociregistry/ociauth: support mixing auth sources

### DIFF
--- a/ociregistry/ociauth/authfile.go
+++ b/ociregistry/ociauth/authfile.go
@@ -56,13 +56,19 @@ var ErrHelperNotFound = errors.New("helper not found")
 // and no error.
 //
 // If the helper doesn't exist, it should return an [ErrHelperNotFound] error.
-type HelperRunner = func(helperName string, serverURL string) (ConfigEntry, error)
+type HelperRunner = func(helperName, serverURL string) (ConfigEntry, error)
 
 // configData holds the part of ~/.docker/config.json that pertains to auth.
 type configData struct {
 	Auths       map[string]authConfig `json:"auths"`
 	CredsStore  string                `json:"credsStore,omitempty"`
 	CredHelpers map[string]string     `json:"credHelpers,omitempty"`
+}
+
+type configSource struct {
+	Name string
+	Path string
+	Raw  []byte
 }
 
 // authConfig contains authorization information for connecting to a Registry.
@@ -96,53 +102,44 @@ func LoadWithEnv(runner HelperRunner, env []string) (*ConfigFile, error) {
 	if env != nil {
 		getenv = getenvFunc(env)
 	}
-	// DOCKER_AUTH_CONFIG has precedence, therefore check if
-	// it has the inlined JSON.
-	if data := getenv("DOCKER_AUTH_CONFIG"); data != "" {
-		f, err := decodeConfigFile([]byte(data))
-		if err != nil {
-			return nil, fmt.Errorf("invalid config: %v", err)
-		}
-		return &ConfigFile{
-			data:   f,
-			runner: runner,
-		}, nil
+	config := &ConfigFile{
+		data: configData{
+			Auths:       map[string]authConfig{},
+			CredsStore:  "",
+			CredHelpers: map[string]string{},
+		},
+		runner: runner,
 	}
-	for _, f := range configFileLocations {
-		filename := f(getenv)
-		if filename == "" {
-			continue
-		}
-		data, err := os.ReadFile(filename)
+	for _, source := range getConfigFileSources(getenv) {
+		data, err := source.Read()
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, err
+			return nil, fmt.Errorf("read %s: %w", source.Name, err)
+		}
+		if len(data) == 0 {
+			continue
 		}
 		f, err := decodeConfigFile(data)
 		if err != nil {
-			return nil, fmt.Errorf("invalid config file %q: %v", filename, err)
+			return nil, fmt.Errorf("invalid config %s: %v", source.Name, err)
 		}
-		return &ConfigFile{
-			data:   f,
-			runner: runner,
-		}, nil
+		f.mergeInto(&config.data)
 	}
-	return &ConfigFile{
-		runner: runner,
-	}, nil
+	return config, nil
 }
 
 // Load loads the auth configuration from the first location it can find.
 // It uses runner to run any external helper commands; if runner
 // is nil, [ExecHelper] will be used.
 //
-// In order, it tries:
-// - $DOCKER_AUTH_CONFIG (inlined JSON)
-// - $DOCKER_CONFIG/config.json
-// - ~/.docker/config.json
-// - $XDG_RUNTIME_DIR/containers/auth.json
+// In order, it loads:
+//
+//  1. $DOCKER_AUTH_CONFIG (inlined JSON)
+//  2. $DOCKER_CONFIG/config.json
+//  3. ~/.docker/config.json
+//  4. $XDG_RUNTIME_DIR/containers/auth.json
+//
+// When multiple of the above sources exist, then authentication for a given
+// registry hostname from earlier sources are prioritized.
 func Load(runner HelperRunner) (*ConfigFile, error) {
 	return LoadWithEnv(runner, nil)
 }
@@ -158,28 +155,69 @@ func getenvFunc(env []string) func(string) string {
 	}
 }
 
-var configFileLocations = []func(func(string) string) string{
-	func(getenv func(string) string) string {
-		if d := getenv("DOCKER_CONFIG"); d != "" {
-			return filepath.Join(d, "config.json")
+func getConfigFileSources(getenv func(string) string) []configSource {
+	var sources []configSource
+	if data := getenv("DOCKER_AUTH_CONFIG"); data != "" {
+		sources = append(sources, configSource{
+			Name: "content of $DOCKER_AUTH_CONFIG",
+			Raw:  []byte(data),
+		})
+	}
+	if d := getenv("DOCKER_CONFIG"); d != "" {
+		sources = append(sources, configSource{
+			Name: "file at $DOCKER_CONFIG",
+			Path: filepath.Join(d, "config.json"),
+		})
+	}
+	if home := userHomeDir(getenv); home != "" {
+		sources = append(sources, configSource{
+			Name: "file at ~/.docker/config.json",
+			Path: filepath.Join(home, ".docker", "config.json"),
+		})
+	}
+	if d := getenv("XDG_RUNTIME_DIR"); d != "" {
+		sources = append(sources, configSource{
+			Name: "file at $XDG_RUNTIME_DIR/containers/auth.json",
+			Path: filepath.Join(d, "containers", "auth.json"),
+		})
+	}
+	return sources
+}
+
+func (s configSource) Read() ([]byte, error) {
+	switch {
+	case s.Raw != nil:
+		return s.Raw, nil
+	case s.Path != "":
+		b, err := os.ReadFile(s.Path)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
 		}
-		return ""
-	},
-	func(getenv func(string) string) string {
-		if home := userHomeDir(getenv); home != "" {
-			return filepath.Join(home, ".docker", "config.json")
+		return b, nil
+	}
+	return nil, nil
+}
+
+func (c configData) mergeInto(other *configData) {
+	for host, value := range c.Auths {
+		if other.Auths == nil {
+			other.Auths = map[string]authConfig{}
 		}
-		return ""
-	},
-	// If neither of the above locations was found, look for Podman's auth at
-	// $XDG_RUNTIME_DIR/containers/auth.json and attempt to load it as a
-	// Docker config.
-	func(getenv func(string) string) string {
-		if d := getenv("XDG_RUNTIME_DIR"); d != "" {
-			return filepath.Join(d, "containers", "auth.json")
+		if _, alreadySet := other.Auths[host]; !alreadySet {
+			other.Auths[host] = value
 		}
-		return ""
-	},
+	}
+	for host, value := range c.CredHelpers {
+		if other.CredHelpers == nil {
+			other.CredHelpers = map[string]string{}
+		}
+		if _, alreadySet := other.CredHelpers[host]; !alreadySet {
+			other.CredHelpers[host] = value
+		}
+	}
+	if c.CredsStore != "" && other.CredsStore == "" {
+		other.CredsStore = c.CredsStore
+	}
 }
 
 // userHomeDir returns the current user's home directory.
@@ -289,10 +327,10 @@ func decodeConfigFile(data []byte) (configData, error) {
 // to keep the logic the same as that.
 func urlHost(url string) string {
 	stripped := url
-	if strings.HasPrefix(url, "http://") {
-		stripped = strings.TrimPrefix(url, "http://")
-	} else if strings.HasPrefix(url, "https://") {
-		stripped = strings.TrimPrefix(url, "https://")
+	if after, ok := strings.CutPrefix(url, "http://"); ok {
+		stripped = after
+	} else if after0, ok0 := strings.CutPrefix(url, "https://"); ok0 {
+		stripped = after0
 	}
 
 	hostName, _, _ := strings.Cut(stripped, "/")
@@ -316,7 +354,7 @@ func decodeAuth(authStr string) (string, string, error) {
 
 // ExecHelper executes an external program to get the credentials from a native store.
 // It implements [HelperRunner].
-func ExecHelper(helperName string, serverURL string) (ConfigEntry, error) {
+func ExecHelper(helperName, serverURL string) (ConfigEntry, error) {
 	return ExecHelperWithEnv(nil)(helperName, serverURL)
 }
 
@@ -325,7 +363,7 @@ func ExecHelper(helperName string, serverURL string) (ConfigEntry, error) {
 // variables to pass to the executed helper command. If env is nil,
 // the current process's environment will be used.
 func ExecHelperWithEnv(env []string) HelperRunner {
-	return func(helperName string, serverURL string) (ConfigEntry, error) {
+	return func(helperName, serverURL string) (ConfigEntry, error) {
 		var out bytes.Buffer
 		cmd := exec.Command("docker-credential-"+helperName, "get")
 		// TODO this doesn't produce a decent error message for

--- a/ociregistry/ociauth/authfile_test.go
+++ b/ociregistry/ociauth/authfile_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-quicktest/qt"
+	"github.com/google/go-cmp/cmp"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -43,28 +44,34 @@ func TestLoad(t *testing.T) {
 		return getenv("HOME")
 	})
 	locations := []struct {
-		env      string
-		dir      string
-		file     string
-		isInline bool
+		extraHost string
+		env       string
+		dir       string
+		file      string
+		isInline  bool
 	}{
 		{
-			env:      "DOCKER_AUTH_CONFIG",
-			isInline: true,
+			extraHost: "inline-docker-auth-env.example.com",
+			env:       "DOCKER_AUTH_CONFIG",
+			isInline:  true,
 		},
 		{
-			env:  "DOCKER_CONFIG",
-			dir:  "dockerconfig",
-			file: "config.json",
+			extraHost: "overridden-dockerconfig.example.com",
+			env:       "DOCKER_CONFIG",
+			dir:       "dockerconfig",
+			file:      "config.json",
 		},
 		{
-			env:  "HOME",
-			dir:  "home",
-			file: ".docker/config.json",
-		}, {
-			env:  "XDG_RUNTIME_DIR",
-			dir:  "xdg",
-			file: "containers/auth.json",
+			extraHost: "default-dockerconfig.example.com",
+			env:       "HOME",
+			dir:       "home",
+			file:      ".docker/config.json",
+		},
+		{
+			extraHost: "runtime-containers-auth.example.com",
+			env:       "XDG_RUNTIME_DIR",
+			dir:       "xdg",
+			file:      "containers/auth.json",
 		},
 	}
 
@@ -73,6 +80,10 @@ func TestLoad(t *testing.T) {
 {
 	"auths": {
 		"someregistry.example.com": {
+			"username": ` + fmt.Sprintf("%q", loc.env) + `,
+			"password": "somepassword"
+		},
+		` + fmt.Sprintf("%q", loc.extraHost) + `: {
 			"username": ` + fmt.Sprintf("%q", loc.env) + `,
 			"password": "somepassword"
 		}
@@ -95,9 +106,23 @@ func TestLoad(t *testing.T) {
 		}
 	}
 	for _, loc := range locations {
-		t.Run(loc.env, func(t *testing.T) {
+		t.Run(loc.env+"/per-source", func(t *testing.T) {
 			c, err := Load(noRunner)
 			qt.Assert(t, qt.IsNil(err))
+
+			info, err := c.EntryForRegistry(loc.extraHost)
+			qt.Assert(t, qt.IsNil(err))
+			qt.Assert(t, qt.Equals(info, ConfigEntry{
+				Username: loc.env,
+				Password: "somepassword",
+			}))
+		})
+	}
+	for _, loc := range locations {
+		t.Run(loc.env+"/precedence", func(t *testing.T) {
+			c, err := Load(noRunner)
+			qt.Assert(t, qt.IsNil(err))
+
 			info, err := c.EntryForRegistry("someregistry.example.com")
 			qt.Assert(t, qt.IsNil(err))
 			qt.Assert(t, qt.Equals(info, ConfigEntry{
@@ -156,7 +181,7 @@ func TestWithMalformedBase64Auth(t *testing.T) {
 		}
 	}
 }`)
-	qt.Assert(t, qt.ErrorMatches(err, `invalid config file ".*": cannot decode auth field for "someregistry.example.com": invalid base64-encoded string`))
+	qt.Assert(t, qt.ErrorMatches(err, `invalid config file at \$DOCKER_CONFIG: cannot decode auth field for "someregistry.example.com": invalid base64-encoded string`))
 }
 
 func TestWithAuthAndUsername(t *testing.T) {
@@ -359,7 +384,7 @@ func TestWithDefaultHelperNotFound(t *testing.T) {
 func TestWithDefaultHelperOtherError(t *testing.T) {
 	// When there's a helper not associated with any specific
 	// host, it's still an error if it's any error other than HelperNotFound.
-	errHelper := func(helperName string, serverURL string) (ConfigEntry, error) {
+	errHelper := func(helperName, serverURL string) (ConfigEntry, error) {
 		return ConfigEntry{}, fmt.Errorf("some error")
 	}
 	c, err := load(t, errHelper, `
@@ -417,6 +442,138 @@ func TestWithHelperAndExplicitEnv(t *testing.T) {
 	}))
 }
 
+func TestConfigSourceRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		source func(t *testing.T) configSource
+		want   []byte
+	}{
+		{
+			name: "zero",
+			source: func(t *testing.T) configSource {
+				return configSource{}
+			},
+			want: nil,
+		},
+		{
+			name: "raw",
+			source: func(t *testing.T) configSource {
+				return configSource{Raw: []byte("hello world")}
+			},
+			want: []byte("hello world"),
+		},
+		{
+			name: "valid file",
+			source: func(t *testing.T) configSource {
+				path := filepath.Join(t.TempDir(), "some-file.txt")
+				err := os.WriteFile(path, []byte("content of some file"), 0o600)
+				qt.Assert(t, qt.IsNil(err))
+				return configSource{Path: path}
+			},
+			want: []byte("content of some file"),
+		},
+		{
+			name: "file not found",
+			source: func(t *testing.T) configSource {
+				return configSource{Path: "/path/that/does/not/exist"}
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.source(t).Read()
+			qt.Assert(t, qt.IsNil(err))
+			qt.Assert(t, qt.DeepEquals(got, test.want))
+		})
+	}
+}
+
+func TestConfigSourceReadError(t *testing.T) {
+	source := configSource{Path: t.TempDir()}
+	_, err := source.Read()
+	qt.Assert(t, qt.IsNotNil(err))
+}
+
+func TestConfigDataMergeInto(t *testing.T) {
+	tests := []struct {
+		name   string
+		config configData
+		other  configData
+		want   configData
+	}{
+		{
+			name:   "zero",
+			config: configData{},
+			other:  configData{},
+			want:   configData{},
+		},
+		{
+			name: "set on empty",
+			config: configData{
+				Auths:       map[string]authConfig{"foo": {Username: "hello"}},
+				CredHelpers: map[string]string{"bar": "echo"},
+				CredsStore:  "cat",
+			},
+			other: configData{},
+			want: configData{
+				Auths:       map[string]authConfig{"foo": {Username: "hello"}},
+				CredHelpers: map[string]string{"bar": "echo"},
+				CredsStore:  "cat",
+			},
+		},
+		{
+			name: "keep original",
+			config: configData{
+				Auths:       map[string]authConfig{"foo": {Username: "hello"}},
+				CredHelpers: map[string]string{"bar": "echo"},
+				CredsStore:  "cat",
+			},
+			other: configData{
+				Auths:       map[string]authConfig{"foo": {Auth: "hmm", IdentityToken: "cool"}},
+				CredHelpers: map[string]string{"bar": "lorem"},
+				CredsStore:  "yes",
+			},
+			want: configData{
+				Auths:       map[string]authConfig{"foo": {Auth: "hmm", IdentityToken: "cool"}},
+				CredHelpers: map[string]string{"bar": "lorem"},
+				CredsStore:  "yes",
+			},
+		},
+		{
+			name: "merge",
+			config: configData{
+				Auths:       map[string]authConfig{"foo": {Username: "hello"}},
+				CredHelpers: map[string]string{"bar": "echo"},
+				CredsStore:  "cat",
+			},
+			other: configData{
+				Auths:       map[string]authConfig{"moo": {Auth: "hmm", IdentityToken: "cool"}},
+				CredHelpers: map[string]string{"doo": "ipsum"},
+			},
+			want: configData{
+				Auths: map[string]authConfig{
+					"foo": {Username: "hello"},
+					"moo": {Auth: "hmm", IdentityToken: "cool"},
+				},
+				CredHelpers: map[string]string{
+					"bar": "echo",
+					"doo": "ipsum",
+				},
+				CredsStore: "cat",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.config.mergeInto(&test.other)
+			qt.Assert(t, qt.CmpEquals(test.other, test.want, cmp.AllowUnexported(authConfig{})))
+		})
+	}
+}
+
 func load(t *testing.T, runner HelperRunner, cfgData string) (Config, error) {
 	d := t.TempDir()
 	t.Setenv("DOCKER_CONFIG", d)
@@ -425,7 +582,7 @@ func load(t *testing.T, runner HelperRunner, cfgData string) (Config, error) {
 	return Load(runner)
 }
 
-func noRunner(helperName string, serverURL string) (ConfigEntry, error) {
+func noRunner(helperName, serverURL string) (ConfigEntry, error) {
 	panic("no helpers available")
 }
 


### PR DESCRIPTION
Changes the way CUE reads authentication from Docker, Podman,
and other tools to allow multiple files being in use instead
of just one.

Before:

- find first file in a list of locations, and use that
- ignores the remaining files

After:

1. load configs from all locations
2. merge them together
3. registry auth still has precedence rules, but it's per registry
   instead of per "config file source location"

Fixes #48, fixes cue-lang/cue#4307
Related discussion: https://github.com/cue-lang/cue/discussions/4306
